### PR TITLE
Fix non-working dialogs

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -70,7 +70,7 @@ class Dialog {
   }
 
   _create(options) {
-    return dialog.showMessageBox(
+    return dialog.showMessageBoxSync(
       Object.assign({
         cancelId: 1,
         defaultId: 0,


### PR DESCRIPTION
A little simple fix for dialogs, including exit confirmation (therefore, fixes #9).