### PR TITLE
Fix list navigation

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -56,11 +56,11 @@ ipc.on('my-day', () => {
 });
 
 ipc.on('important', () => {
-  nav.click('#smart_list_important');
+  nav.click('.listItem-container > #important');
 });
 
 ipc.on('planned', () => {
-  nav.click('#smart_list_planned');
+  nav.click('.listItem-container > #planned');
 });
 
 ipc.on('tasks', () => {

--- a/src/nav.js
+++ b/src/nav.js
@@ -6,11 +6,11 @@ const settings = require('./settings');
 class Nav {
   constructor() {
     this._defaultZoomFactor = 1.0;
-    this._listItem = '.listItem';
+    this._listItem = '.listItem-container';
     this._lists = '.lists';
     this._lowerZoomLimit = 0.7;
     this._myDayList = '.todayToolbar-item';
-    this._selectedListItem = '.active';
+    this._selectedListClass = 'active';
     this._upperZoomLimit = 1.3;
     this._zoomStep = 0.05;
   }
@@ -28,17 +28,15 @@ class Nav {
   }
 
   _currentIdx() {
-    let currentIdx = 0;
     const lists = this._getLists();
-    const selectedList = this.select(this._selectedListItem);
 
     for (let i = 0; i < lists.length; i++) {
-      if (lists[i] === selectedList) {
-        currentIdx += i;
+      if (lists[i].classList.contains(this._selectedListClass)) {
+        return i;
       }
     }
-
-    return currentIdx;
+    
+    return 0;
   }
 
   _getLists() {
@@ -85,7 +83,7 @@ class Nav {
   selectList(idx) {
     if (idx >= 0 && idx <= this._lastIdx) {
       const lists = this._getLists();
-      const {id, className} = lists[idx];
+      const {id, className} = lists[idx].children[0];
       return id ? this._clickId(id) : this._clickClass(className);
     }
   }

--- a/src/nav.js
+++ b/src/nav.js
@@ -27,8 +27,8 @@ class Nav {
     document.getElementById(x).click();
   }
 
-  _currentIdx() {
-    const lists = this._getLists();
+  _currentIdx(lists) {
+    if (lists == null) lists = this._getLists();
 
     for (let i = 0; i < lists.length; i++) {
       if (lists[i].classList.contains(this._selectedListClass)) {
@@ -67,22 +67,24 @@ class Nav {
   }
 
   nextList() {
-    const idx = this._currentIdx();
-    this.selectList(idx === this._lastIdx ? 0 : idx + 1);
+    const lists = this._getLists();
+    const idx = this._currentIdx(lists);
+    this.selectList(idx === this._lastIdx ? 0 : idx + 1, lists);
   }
 
   previousList() {
-    const idx = this._currentIdx();
-    return this.selectList(idx === 0 ? this._lastIdx : idx - 1);
+    const lists = this._getLists();
+    const idx = this._currentIdx(lists);
+    return this.selectList(idx === 0 ? this._lastIdx : idx - 1, lists);
   }
 
   select(x) {
     return document.querySelector(x);
   }
 
-  selectList(idx) {
+  selectList(idx, lists) {
     if (idx >= 0 && idx <= this._lastIdx) {
-      const lists = this._getLists();
+      if (lists == null) lists = this._getLists();
       const {id, className} = lists[idx].children[0];
       return id ? this._clickId(id) : this._clickClass(className);
     }


### PR DESCRIPTION
Fixes #13.

Culprits were [browser.js](https://github.com/pythonInRelay/ao/blob/master/src/browser.js) and [nav.js](https://github.com/pythonInRelay/ao/blob/master/src/nav.js). 

I hope the list switch fix won't impact performance much, as it uses class list search to find the active list. And yet it's more robust than the older way imo. 

**UPD**: I've tried to reduce an amount of selector queries a little, so it should work even quickier.
However, there's a little feature: it ignores lists in collapsed groups. I think, that would be actually a separate feature request.