### PR TITLE
Handful of fixes (#16, #18)

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ lib, fetchFromGitHub
 , makeWrapper, makeDesktopItem, mkYarnPackage
 , electron_9, yarn2nix
 }:
@@ -41,6 +41,7 @@ in mkYarnPackage rec {
     
     # executable wrapper
     makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
+      --argv0 "ao" \
       --add-flags "$out/share/ao/electron"
   '';
 
@@ -50,7 +51,7 @@ in mkYarnPackage rec {
     true
   '';
 
-  desktopItem = with stdenv.lib; 
+  desktopItem = with lib; 
     makeDesktopItem {
       name = "ao";
       exec = executableName;
@@ -65,7 +66,7 @@ in mkYarnPackage rec {
       '';
     };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = ''
       Ao is an unofficial, featureful, open source, 
       community-driven, free Microsoft To-Do app, 

--- a/src/menu/file.js
+++ b/src/menu/file.js
@@ -166,7 +166,7 @@ module.exports = {
       label: 'Edit Shortcut Keys',
       accelerator: 'CmdorCtrl+.',
       click() {
-        shell.openExternal(file.localConfig);
+        shell.openPath(file.localConfig);
       }
     }, {
       label: 'Enable Global Shortcut Keys',

--- a/src/style/browser.css
+++ b/src/style/browser.css
@@ -49,3 +49,6 @@ html.side-bar-hidden #container.leftColumn-overlaid #app {
 .listItem, .listItem .listItem-icon {
   background-color: transparent !important;
 }
+.sidebar-footer { 
+  display: none; 
+}


### PR DESCRIPTION
 - Fix "Edit Shortcut Keys" action (closes #16)
 - Hide Outlook apps footer, as Ao is ToDo client (closes #18)
 - Nix package housekeeping (replace deprecated `stdenv.lib` with `lib`)